### PR TITLE
chore(logging-lib): configure Roslyn analyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,6 @@ csharp_indent_switch_labels = true
 
 dotnet_style_qualification_for_field = false:suggestion
 dotnet_style_qualification_for_property = false:suggestion
+
+# Roslyn analyzers
+dotnet_analyzer_diagnostic.severity = warning

--- a/Hm.Logging/Hm.Logging.csproj
+++ b/Hm.Logging/Hm.Logging.csproj
@@ -17,6 +17,12 @@
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+		<AnalysisLevel>latest-recommended</AnalysisLevel>
+		<TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+	</PropertyGroup>
+	
 	<ItemGroup>
 		<Folder Include="Abstractions\" />
 		<Folder Include="Models\" />


### PR DESCRIPTION
## Summary
Enable Roslyn analyzers to improve code quality and static analysis.

## Changes
- Enabled built-in .NET analyzers
- Set analysis level to latest-recommended
- Configured default analyzer severity to warning in .editorconfig

## Notes
This introduces automated code analysis to detect potential issues and enforce best practices without blocking development.

## Impact
No functional changes. Only code quality configuration.

## Related Issue
Resolves #5 