### PR TITLE
[LIB] Create LogContext model and contextual logging support

### DIFF
--- a/Hm.Logging/Abstractions/ILoggerService.cs
+++ b/Hm.Logging/Abstractions/ILoggerService.cs
@@ -9,6 +9,68 @@ namespace Hm.Logging.Abstractions
     public interface ILoggerService
     {
         /// <summary>
+        /// Sets the logging context to be applied to all subsequent log entries
+        /// within the current execution flow.
+        /// </summary>
+        /// <param name="context">
+        /// The <see cref="LogContext"/> containing shared values such as Source,
+        /// TraceId, and Metadata.
+        /// </param>
+        /// <remarks>
+        /// The context provides default values that will be automatically applied
+        /// to each <see cref="LogEntry"/>.
+        ///
+        /// <para>
+        /// When a property exists in both <see cref="LogContext"/> and <see cref="LogEntry"/>,
+        /// the value defined in <see cref="LogEntry"/> takes precedence.
+        /// </para>
+        ///
+        /// <para>
+        /// For example:
+        /// </para>
+        /// <code>
+        /// logger.SetContext(new LogContext
+        /// {
+        ///     Source = "AuthService",
+        ///     TraceId = "abc-123"
+        /// });
+        ///
+        /// await logger.LogAsync(new LogEntry
+        /// {
+        ///     Message = "Special operation",
+        ///     TraceId = "override-999"
+        /// });
+        /// </code>
+        ///
+        /// <para>
+        /// Resulting log:
+        /// </para>
+        /// <code>
+        /// {
+        ///   "message": "Special operation",
+        ///   "source": "AuthService",
+        ///   "traceId": "override-999"
+        /// }
+        /// </code>
+        ///
+        /// <para>
+        /// Metadata from both context and entry will be merged. If the same key exists,
+        /// the value from <see cref="LogEntry"/> overrides the one from <see cref="LogContext"/>.
+        /// </para>
+        ///
+        /// <para>
+        /// This method is typically called once per execution scope
+        /// (e.g., per HTTP request, background job, or transaction).
+        /// </para>
+        ///
+        /// <para>
+        /// Internally, the context is stored per execution flow, ensuring that
+        /// concurrent operations do not interfere with each other.
+        /// </para>
+        /// </remarks>
+        void SetContext(LogContext context);
+
+        /// <summary>
         /// Logs a structured log entry asynchronously.
         /// </summary>
         /// <param name="entry">The log entry containing all relevant data.</param>

--- a/Hm.Logging/Models/LogContext.cs
+++ b/Hm.Logging/Models/LogContext.cs
@@ -1,0 +1,52 @@
+﻿namespace Hm.Logging.Models
+{
+    /// <summary>
+    /// Represents contextual information shared across multiple log entries
+    /// within the same execution flow (e.g., a request, background job, or transaction).
+    /// 
+    /// This avoids repeating common values such as TraceId, Source, or shared metadata
+    /// in every log entry.
+    /// 
+    /// Values defined in the context act as defaults and can be overridden
+    /// by individual <see cref="LogEntry"/> instances.
+    /// </summary>
+    /// <remarks>
+    /// A context is typically set once and reused across multiple logs:
+    /// 
+    /// <code>
+    /// logger.SetContext(new LogContext
+    /// {
+    ///     Source = "AuthService",
+    ///     TraceId = "abc-123",
+    ///     Metadata = new Dictionary&lt;string, object&gt;
+    ///     {
+    ///         ["userId"] = "u-001"
+    ///     }
+    /// });
+    /// 
+    /// await logger.LogAsync(new LogEntry
+    /// {
+    ///     Message = "User login started"
+    /// });
+    /// </code>
+    /// 
+    /// In this example, the log entry will automatically include the Source, TraceId, and Metadata from the context.
+    /// </remarks>
+    public class LogContext
+    {
+        /// <summary>
+        /// Logical source of the logs (e.g., service or application name).
+        /// </summary>
+        public string? Source { get; init; }
+
+        /// <summary>
+        /// Correlation identifier for distributed tracing.
+        /// </summary>
+        public string? TraceId { get; init; }
+
+        /// <summary>
+        /// Additional contextual metadata applied to all log entries.
+        /// </summary>
+        public Dictionary<string, object>? Metadata { get; init; }
+    }
+}

--- a/Hm.Logging/Models/LogEntry.cs
+++ b/Hm.Logging/Models/LogEntry.cs
@@ -3,9 +3,72 @@
 namespace Hm.Logging.Models
 {
     /// <summary>
-    /// Represents a structured log entry used for logging events across the system.
-    /// Designed to be compatible with modern observability and monitoring platforms.
+    /// Represents a structured log entry describing a specific event in the system.
     /// </summary>
+    /// <remarks>
+    /// A <see cref="LogEntry"/> contains the data specific to a single log event,
+    /// such as the message, severity level, and optional contextual overrides.
+    ///
+    /// <para>
+    /// When a <see cref="LogContext"/> is set via the logger, its values are applied
+    /// as defaults to all log entries.
+    /// </para>
+    ///
+    /// <para>
+    /// If a property is defined in both <see cref="LogContext"/> and <see cref="LogEntry"/>,
+    /// the value in <see cref="LogEntry"/> takes precedence.
+    /// </para>
+    ///
+    /// <para><b>Override example:</b></para>
+    /// <code>
+    /// logger.SetContext(new LogContext
+    /// {
+    ///     Source = "AuthService",
+    ///     TraceId = "abc-123"
+    /// });
+    ///
+    /// await logger.LogAsync(new LogEntry
+    /// {
+    ///     Message = "User login",
+    ///     TraceId = "override-999"
+    /// });
+    /// </code>
+    ///
+    /// <para>
+    /// Result:
+    /// </para>
+    /// <code>
+    /// {
+    ///   "message": "User login",
+    ///   "source": "AuthService",
+    ///   "traceId": "override-999"
+    /// }
+    /// </code>
+    ///
+    /// <para><b>Metadata merging:</b></para>
+    /// <code>
+    /// // Context
+    /// Metadata = { ["service"] = "auth" }
+    ///
+    /// // Entry
+    /// Metadata = { ["userId"] = "123" }
+    /// </code>
+    ///
+    /// <para>
+    /// Result:
+    /// </para>
+    /// <code>
+    /// {
+    ///   "service": "auth",
+    ///   "userId": "123"
+    /// }
+    /// </code>
+    ///
+    /// <para>
+    /// In case of duplicate keys, values from <see cref="LogEntry"/> override
+    /// those from <see cref="LogContext"/>.
+    /// </para>
+    /// </remarks>
     public class LogEntry
     {
         /// <summary>
@@ -48,6 +111,7 @@ namespace Hm.Logging.Models
         /// <summary>
         /// Additional structured data for the log entry.
         /// Enables advanced filtering and querying in monitoring tools.
+        /// Values are merged with those from <see cref="LogContext"/> if present.
         /// </summary>
         public Dictionary<string, object>? Metadata { get; init; }
     }


### PR DESCRIPTION
## Summary
Introduce the LogContext model to support contextual logging and reduce repetition of shared log data across multiple log entries.

## Changes
- Added LogContext model with Source, TraceId, and Metadata fields
- Extended ILoggerService with SetContext method
- Defined context-aware logging behavior
- Implemented override rules:
  - LogEntry values take precedence over LogContext
- Implemented metadata merging between context and entry
- Added comprehensive XML documentation with examples

## Design Decisions
- LogContext represents shared data within an execution flow (e.g., request, job)
- LogEntry represents a single log event
- Context is applied automatically and not passed explicitly per log
- Clear separation of responsibilities between context and entry

## Behavior
- Context values act as defaults
- Entry values override context when both are present
- Metadata is merged (entry overrides duplicate keys)

## Example

```csharp
logger.SetContext(new LogContext
{
    Source = "AuthService",
    TraceId = "abc-123"
});

await logger.LogAsync(new LogEntry
{
    Message = "User login",
    TraceId = "override-999"
});
```
```csharp
##Result
{
  "message": "User login",
  "source": "AuthService",
  "traceId": "override-999"
}
```
___
Impact
Enables contextual logging across execution flows
Reduces duplication of common log data
Improves consistency and traceability

Notes
Context is scoped to the execution flow (not global)
Designed to be compatible with async and concurrent scenarios
Related Issue

Resolves #10