### PR TITLE
[LIB] Define ILogRepository interface

### DIFF
--- a/Hm.Logging/Abstractions/ILogRepository.cs
+++ b/Hm.Logging/Abstractions/ILogRepository.cs
@@ -1,0 +1,21 @@
+﻿using Hm.Logging.Models;
+
+namespace Hm.Logging.Abstractions
+{
+    /// <summary>
+    /// Defines a contract for persisting log entries to a storage medium.
+    /// </summary>
+    internal interface ILogRepository
+    {
+        /// <summary>
+        /// Persists a log entry asynchronously.
+        /// </summary>
+        /// <param name="entry">
+        /// The <see cref="LogEntry"/> to be stored.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// Token to cancel the operation.
+        /// </param>
+        Task SaveAsync(LogEntry entry, CancellationToken cancellationToken = default);
+    }
+}


### PR DESCRIPTION
## Summary
Introduce the ILogRepository abstraction to handle log persistence in a decoupled and extensible way.

## Changes
- Added ILogRepository interface
- Defined asynchronous SaveAsync method for log persistence
- Established write-only contract for logging operations

## Design Decisions
- Logging is treated as a write-only operation
- Repository abstraction allows multiple storage implementations (DB, file, external systems)

## Impact
- Enables decoupling between ILoggerService and persistence mechanisms
- Provides a foundation for multiple logging providers
- Keeps the core library lightweight and storage-agnostic

## Notes
- No persistence implementations are included in this package
- Implementations are expected to be defined in external providers

## Related Issue
Resolves #7