### PR TITLE
[LIB] Add CorrelationId support to structured logging pipeline

### DIFF
--- a/Hm.Logging/Abstractions/ILoggerService.cs
+++ b/Hm.Logging/Abstractions/ILoggerService.cs
@@ -23,13 +23,15 @@ namespace Hm.Logging.Abstractions
     /// Logging scopes allow shared contextual information such as
     /// <see cref="LogContext.Source"/>,
     /// <see cref="LogContext.TraceId"/>,
+    /// <see cref="LogContext.CorrelationId"/>,
     /// and shared metadata to be automatically applied
     /// to all logs created within the current execution flow.
     /// </para>
     ///
     /// <para>
     /// When values exist in both <see cref="LogContext"/> and <see cref="LogEntry"/>,
-    /// the values defined in <see cref="LogEntry"/> take precedence.
+    /// the values defined in <see cref="LogEntry"/> take precedence,
+    /// including TraceId, CorrelationId, Source, and Metadata values.
     /// </para>
     /// </remarks>
     public interface ILoggerService
@@ -56,7 +58,8 @@ namespace Hm.Logging.Abstractions
         /// using (logger.BeginScope(new LogContext
         /// {
         ///     Source = "AuthService",
-        ///     TraceId = "abc-123"
+        ///     TraceId = "trace-123",
+        ///     CorrelationId = "corr-checkout-001"
         /// }))
         /// {
         ///     await logger.LogAsync(LogEntry.Info("User login started"));

--- a/Hm.Logging/Core/LoggerService.cs
+++ b/Hm.Logging/Core/LoggerService.cs
@@ -72,6 +72,7 @@ namespace Hm.Logging.Core
             return context is null ? entry : (entry with
             {
                 TraceId = entry.TraceId ?? context.TraceId,
+                CorrelationId = entry.CorrelationId ?? context.CorrelationId,
                 Source = entry.Source ?? context.Source,
                 Metadata = MergeMetadata(context.Metadata, entry.Metadata)
             });

--- a/Hm.Logging/Core/Metadata/ReservedMetadataKeys.cs
+++ b/Hm.Logging/Core/Metadata/ReservedMetadataKeys.cs
@@ -23,6 +23,7 @@
         new HashSet<string>(StringComparer.Ordinal)
         {
             "TraceId",
+            "CorrelationId",
             "Timestamp",
             "Level",
             "Message",

--- a/Hm.Logging/Extensions/LogEntryValidationExtensions.cs
+++ b/Hm.Logging/Extensions/LogEntryValidationExtensions.cs
@@ -103,6 +103,8 @@ namespace Hm.Logging.Extensions
                         ?? traceContext.GetTraceId()
                         ?? Guid.NewGuid().ToString(),
 
+                CorrelationId = Normalize(logEntry.CorrelationId),
+
                 Exception = Normalize(logEntry.Exception),
                 Metadata = logEntry.Metadata.EnsureValidMetadata()
             };

--- a/Hm.Logging/Models/LogContext.cs
+++ b/Hm.Logging/Models/LogContext.cs
@@ -19,7 +19,8 @@ namespace Hm.Logging.Models
     /// using (logger.BeginScope(new LogContext
     /// {
     ///     Source = "AuthService",
-    ///     TraceId = "abc-123",
+    ///     TraceId = "trace-123",
+    ///     CorrelationId = "corr-checkout-001",
     ///     Metadata = ImmutableDictionary&lt;string, object&gt;
     ///         .Empty
     ///         .Add("userId", "u-001")
@@ -42,9 +43,21 @@ namespace Hm.Logging.Models
         public string? Source { get; init; }
 
         /// <summary>
-        /// Correlation identifier for distributed tracing.
+        /// Trace identifier associated with the current execution flow.
         /// </summary>
         public string? TraceId { get; init; }
+
+        /// <summary>
+        /// Identifier used to correlate related operations
+        /// across multiple services, requests, or workflows.
+        /// </summary>
+        /// <remarks>
+        /// CorrelationId values defined within a logging scope
+        /// are automatically propagated to all log entries
+        /// created within the current execution flow,
+        /// unless explicitly overridden by the log entry.
+        /// </remarks>
+        public string? CorrelationId { get; init; }
 
         /// <summary>
         /// Additional contextual metadata applied to all log entries.

--- a/Hm.Logging/Models/LogEntry.cs
+++ b/Hm.Logging/Models/LogEntry.cs
@@ -25,7 +25,7 @@ namespace Hm.Logging.Models
     /// using (logger.BeginScope(new LogContext
     /// {
     ///     Source = "AuthService",
-    ///     TraceId = "abc-123",
+    ///     TraceId = "trace-123",
     ///     CorrelationId = "corr-checkout-001"
     /// }))
     /// {

--- a/Hm.Logging/Models/LogEntry.cs
+++ b/Hm.Logging/Models/LogEntry.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Immutable;
-using Hm.Logging.Abstractions;
 using Hm.Logging.Enums;
 
 namespace Hm.Logging.Models
@@ -26,13 +25,15 @@ namespace Hm.Logging.Models
     /// using (logger.BeginScope(new LogContext
     /// {
     ///     Source = "AuthService",
-    ///     TraceId = "abc-123"
+    ///     TraceId = "abc-123",
+    ///     CorrelationId = "corr-checkout-001"
     /// }))
     /// {
     ///     await logger.LogAsync(new LogEntry
     ///     {
     ///         Message = "User login",
-    ///         TraceId = "override-999"
+    ///         TraceId = "override-999",
+    ///         CorrelationId = "corr-payment-002"
     ///     });
     /// }
     /// </code>
@@ -44,7 +45,8 @@ namespace Hm.Logging.Models
     /// {
     ///   "message": "User login",
     ///   "source": "AuthService",
-    ///   "traceId": "override-999"
+    ///   "traceId": "override-999",
+    ///   "correlationId": "corr-payment-002"
     /// }
     /// </code>
     ///
@@ -98,11 +100,25 @@ namespace Hm.Logging.Models
         public string? Source { get; init; }
 
         /// <summary>
-        /// Correlation identifier used to trace requests across distributed systems.
-        /// It is recommended to populate this value using an <see cref="ITraceContext"/>
-        /// implementation or any distributed tracing mechanism (e.g., Activity).
+        /// Trace identifier associated with the current execution flow.
+        /// Typically used for technical request tracing and diagnostics.
         /// </summary>
+        /// <remarks>
+        /// This value is commonly populated from distributed tracing systems
+        /// such as <see cref="System.Diagnostics.Activity"/>.
+        /// </remarks>
         public string? TraceId { get; init; }
+
+        /// <summary>
+        /// Identifier used to correlate related operations
+        /// across multiple services, requests, or workflows.
+        /// </summary>
+        /// <remarks>
+        /// Unlike <see cref="TraceId"/>, which represents the current
+        /// execution trace, CorrelationId is typically propagated
+        /// across distributed boundaries and business operations.
+        /// </remarks>
+        public string? CorrelationId { get; init; }
 
         /// <summary>
         /// Serialized exception details, if any.
@@ -143,9 +159,13 @@ namespace Hm.Logging.Models
         /// <see cref="Info(string)"/>, <see cref="Warning(string)"/>, or
         /// <see cref="Error(string, Exception)"/>, which simplify log creation for specific levels.
         ///
+        /// <para>
         /// Additional properties such as <see cref="Source"/>,
-        /// <see cref="TraceId"/>, and <see cref="Metadata"/> can be
+        /// <see cref="TraceId"/>,
+        /// <see cref="CorrelationId"/>,
+        /// and <see cref="Metadata"/> can be
         /// optionally set after creation or enriched automatically by the logging pipeline.
+        /// </para>
         /// </remarks>
         public static LogEntry Create(string message, LogLevel level = LogLevel.Information)
         {


### PR DESCRIPTION
## Summary

Added CorrelationId support across the structured logging pipeline to improve distributed tracing and cross-service operation correlation.

This feature introduces CorrelationId as a first-class logging property with contextual propagation support through logging scopes while preserving immutable processing behavior and provider-agnostic orchestration.

## Changes

- Added `CorrelationId` to `LogEntry`
- Added `CorrelationId` to `LogContext`
- Added CorrelationId contextual propagation support through scopes
- Updated contextual merge behavior in `LoggerService`
- Added CorrelationId normalization during validation
- Added CorrelationId reserved metadata protection
- Improved distributed tracing semantics documentation
- Improved TraceId vs CorrelationId conceptual separation
- Updated XML documentation and usage examples

## Architectural Improvements

- Distributed correlation support
- Cross-service traceability
- Immutable contextual propagation
- Provider-agnostic correlation handling
- Improved observability semantics

## Notes

CorrelationId is intentionally not auto-generated by the logging pipeline.

It is expected to originate from external orchestration boundaries such as:
- HTTP requests
- API gateways
- messaging systems
- workflows
- distributed business operations

The pipeline preserves existing precedence behavior where `LogEntry` values override `LogContext` values when both are defined.

## Related Issue

Resolves #40 