### PR TITLE
[TESTS] Add unit tests for LoggerService orchestration

### DIFF
--- a/tests/Hm.Logging.Tests/Core/LoggerServiceTests.cs
+++ b/tests/Hm.Logging.Tests/Core/LoggerServiceTests.cs
@@ -1,0 +1,410 @@
+﻿using System.Collections.Immutable;
+using FluentAssertions;
+using Hm.Logging.Abstractions;
+using Hm.Logging.Configuration;
+using Hm.Logging.Enums;
+using Hm.Logging.Extensions;
+using Hm.Logging.Models;
+using Hm.Logging.Tests.Mocks;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Hm.Logging.Tests.Core;
+
+public sealed class LoggerServiceTests
+{
+    [Fact]
+    public async Task LogAsync_ShouldExecuteSuccessfully_ForValidLogEntry()
+    {
+        // Arrange
+        FakeLogProvider provider = new();
+        ILoggerService logger = CreateLoggerService(providers: provider);
+        var entry = LogEntry.Info("Test message");
+
+        // Act
+        await logger.LogAsync(entry, CancellationToken.None);
+
+        // Assert
+        provider.Entries.Should().HaveCount(1);
+
+        provider.Entries[0].Message.Should().Be("Test message");
+        provider.Entries[0].Level.Should().Be(LogLevel.Information);
+    }
+
+    [Fact]
+    public async Task LogAsync_ShouldThrow_WhenLogEntryIsNull()
+    {
+        // Arrange
+        FakeLogProvider provider = new();
+        ILoggerService logger = CreateLoggerService(providers: provider);
+
+        // Act
+        Func<Task> action = async () => await logger.LogAsync(null!);
+
+        // Assert
+        await action.Should()
+            .ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task LogAsync_ShouldIgnoreLogEntries_BelowMinimumLevel()
+    {
+        // Arrange
+        FakeLogProvider provider = new();
+
+        ILoggerService logger = CreateLoggerService(
+            options =>
+            {
+                options.MinimumLevel = LogLevel.Warning;
+            },
+            provider);
+
+        var entry = LogEntry.Info("Ignored message");
+
+        // Act
+        await logger.LogAsync(entry, CancellationToken.None);
+
+        // Assert
+        provider.Entries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LogAsync_ShouldDispatchLogEntry_ToProvider()
+    {
+        // Arrange
+        FakeLogProvider provider = new();
+        ILoggerService logger = CreateLoggerService(providers: provider);
+        var entry = LogEntry.Warning("Warning message");
+
+        // Act
+        await logger.LogAsync(entry, CancellationToken.None);
+
+        // Assert
+        provider.Entries.Should().ContainSingle();
+        provider.Entries[0].Message.Should().Be("Warning message");
+        provider.Entries[0].Level.Should().Be(LogLevel.Warning);
+    }
+
+    [Fact]
+    public async Task LogAsync_ShouldDispatchLogEntry_ToMultipleProviders()
+    {
+        // Arrange
+        FakeLogProvider provider1 = new();
+        FakeLogProvider provider2 = new();
+
+        ILoggerService logger = CreateLoggerService(providers: [provider1, provider2]);
+
+        var entry = LogEntry.Info("Multi-provider message");
+
+        // Act
+        await logger.LogAsync(entry, CancellationToken.None);
+
+        // Assert
+        provider1.Entries.Should().ContainSingle();
+        provider2.Entries.Should().ContainSingle();
+        provider1.Entries[0].Message.Should().Be("Multi-provider message");
+        provider2.Entries[0].Message.Should().Be("Multi-provider message");
+    }
+
+    [Fact]
+    public async Task LogAsync_ShouldNormalizeLogEntry_BeforeProviderExecution()
+    {
+        // Arrange
+        FakeLogProvider provider = new();
+        ILoggerService logger = CreateLoggerService(providers: provider);
+
+        LogEntry entry = new()
+        {
+            Message = "   Normalized message   "
+        };
+
+        // Act
+        await logger.LogAsync(entry, CancellationToken.None);
+
+        // Assert
+        provider.Entries.Should().ContainSingle();
+        provider.Entries[0].Message.Should().Be("Normalized message");
+    }
+
+    [Fact]
+    public async Task LogAsync_ShouldAssignTraceId_FromTraceContext()
+    {
+        // Arrange
+        FakeLogProvider provider = new();
+        ILoggerService logger = CreateLoggerService(providers: provider);
+        var entry = LogEntry.Info("Trace test");
+
+        // Act
+        await logger.LogAsync(entry, CancellationToken.None);
+
+        // Assert
+        provider.Entries.Should().ContainSingle();
+        provider.Entries[0].TraceId.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task LogAsync_ShouldThrow_WhenMessageExceedsMaximumLength()
+    {
+        // Arrange
+        FakeLogProvider provider = new();
+
+        ILoggerService logger = CreateLoggerService(
+            options =>
+            {
+                options.MaxMessageLength = 10;
+            },
+            provider);
+
+        var entry = LogEntry.Info("This message is definitely too long");
+
+        // Act
+        Func<Task> action = async () => await logger.LogAsync(entry);
+
+        // Assert
+        await action.Should()
+            .ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task LogAsync_ShouldAllowUnlimitedMessageLength_WhenMaxLengthIsZero()
+    {
+        // Arrange
+        FakeLogProvider provider = new();
+
+        ILoggerService logger = CreateLoggerService(
+            options =>
+            {
+                options.MaxMessageLength = 0;
+            },
+            provider);
+
+        var entry = LogEntry.Info(new string('A', 5000));
+
+        // Act
+        await logger.LogAsync(entry, CancellationToken.None);
+
+        // Assert
+        provider.Entries.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task LogAsync_ShouldNotSwallowProviderExceptions()
+    {
+        // Arrange
+        FakeLogProvider provider = new()
+        {
+            ThrowException = true
+        };
+
+        ILoggerService logger = CreateLoggerService(providers: provider);
+
+        var entry = LogEntry.Error("Provider failure test",
+                                   new InvalidOperationException("Failure"));
+
+        // Act
+        Func<Task> action = async () => await logger.LogAsync(entry, CancellationToken.None);
+
+        // Assert
+        await action.Should()
+            .ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task LogAsync_ShouldMergeScopeContext_WithLogEntry()
+    {
+        // Arrange
+        FakeLogProvider provider = new();
+        ILoggerService logger = CreateLoggerService(providers: provider);
+
+        LogContext context = new()
+        {
+            TraceId = "scope-trace-id",
+            CorrelationId = "scope-correlation-id",
+            Source = "scope-source",
+            Metadata = ImmutableDictionary<string, object>.Empty
+                .Add("Environment", "Production")
+        };
+
+        using IDisposable scope = logger.BeginScope(context);
+
+        var entry = LogEntry.Info("Scoped message");
+
+        // Act
+        await logger.LogAsync(entry, CancellationToken.None);
+
+        // Assert
+        provider.Entries.Should().ContainSingle();
+
+        LogEntry loggedEntry = provider.Entries[0];
+
+        loggedEntry.TraceId.Should().Be("scope-trace-id");
+        loggedEntry.CorrelationId.Should().Be("scope-correlation-id");
+        loggedEntry.Source.Should().Be("scope-source");
+
+        loggedEntry.Metadata.Should().NotBeNull();
+        loggedEntry.Metadata["Environment"].Should().Be("Production");
+    }
+
+    [Fact]
+    public async Task LogAsync_ShouldPreserveLogEntryValues_OverScopeContext()
+    {
+        // Arrange
+        FakeLogProvider provider = new();
+        ILoggerService logger = CreateLoggerService(providers: provider);
+
+        LogContext context = new()
+        {
+            TraceId = "scope-trace-id",
+            CorrelationId = "scope-correlation-id",
+            Source = "scope-source"
+        };
+
+        using IDisposable scope = logger.BeginScope(context);
+
+        LogEntry entry = new()
+        {
+            Message = "Scoped override",
+            TraceId = "entry-trace-id",
+            CorrelationId = "entry-correlation-id",
+            Source = "entry-source"
+        };
+
+        // Act
+        await logger.LogAsync(entry, CancellationToken.None);
+
+        // Assert
+        provider.Entries.Should().ContainSingle();
+
+        LogEntry loggedEntry = provider.Entries[0];
+
+        loggedEntry.TraceId.Should().Be("entry-trace-id");
+        loggedEntry.CorrelationId.Should().Be("entry-correlation-id");
+        loggedEntry.Source.Should().Be("entry-source");
+    }
+
+    [Fact]
+    public async Task LogAsync_ShouldMergeMetadata_FromScopeAndLogEntry()
+    {
+        // Arrange
+        FakeLogProvider provider = new();
+        ILoggerService logger = CreateLoggerService(providers: provider);
+
+        LogContext context = new()
+        {
+            Metadata = ImmutableDictionary<string, object>.Empty
+                .Add("Environment", "Production")
+                .Add("Version", "1.0")
+        };
+
+        using IDisposable scope = logger.BeginScope(context);
+
+        LogEntry entry = new()
+        {
+            Message = "Metadata merge",
+            Metadata = ImmutableDictionary<string, object>.Empty
+                .Add("UserId", "123")
+                .Add("Version", "2.0")
+        };
+
+        // Act
+        await logger.LogAsync(entry, CancellationToken.None);
+
+        // Assert
+        provider.Entries.Should().ContainSingle();
+
+        LogEntry loggedEntry = provider.Entries[0];
+
+        loggedEntry.Metadata.Should().NotBeNull();
+
+        loggedEntry.Metadata["Environment"].Should().Be("Production");
+        loggedEntry.Metadata["UserId"].Should().Be("123");
+
+        // Entry metadata should override context metadata
+        loggedEntry.Metadata["Version"].Should().Be("2.0");
+    }
+
+    [Fact]
+    public async Task LogAsync_ShouldExecuteSuccessfully_WhenNoProvidersAreRegistered()
+    {
+        // Arrange
+        ILoggerService logger = CreateLoggerService();
+        var entry = LogEntry.Info("No providers");
+
+        // Act
+        Func<Task> action = async () => await logger.LogAsync(entry, CancellationToken.None);
+
+        // Assert
+        await action.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task LogAsync_ShouldPreserveImmutableLogEntryBehavior()
+    {
+        // Arrange
+        FakeLogProvider provider = new();
+        ILoggerService logger = CreateLoggerService(providers: provider);
+
+        LogEntry originalEntry = new()
+        {
+            Message = "   Immutable message   "
+        };
+
+        // Act
+        await logger.LogAsync(originalEntry, CancellationToken.None);
+
+        // Assert
+        provider.Entries.Should().ContainSingle();
+
+        originalEntry.Message.Should().Be("   Immutable message   ");
+
+        provider.Entries[0].Message.Should().Be("Immutable message");
+
+        provider.Entries[0].Should().NotBeSameAs(originalEntry);
+    }
+
+    [Fact]
+    public async Task LogAsync_ShouldPropagateCancellationToken_ToProviders()
+    {
+        // Arrange
+        CancellationToken receivedToken = default;
+        Mock<ILogProvider> providerMock = new();
+
+        providerMock
+            .Setup(x => x.WriteAsync(
+                It.IsAny<LogEntry>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<LogEntry, CancellationToken>((_, token) =>
+            {
+                receivedToken = token;
+            })
+            .Returns(Task.CompletedTask);
+
+        ILoggerService logger = CreateLoggerService(providers: providerMock.Object);
+
+        var entry = LogEntry.Info("Cancellation token test");
+
+        using CancellationTokenSource cancellationTokenSource = new();
+
+        // Act
+        await logger.LogAsync(entry, cancellationTokenSource.Token);
+
+        // Assert
+        receivedToken.Should().Be(cancellationTokenSource.Token);
+    }
+
+    private static ILoggerService CreateLoggerService(Action<LoggingOptions>? configure = null,
+                                                      params ILogProvider[] providers)
+    {
+        ServiceCollection services = new();
+        services.AddHmLogging(options => configure?.Invoke(options));
+
+        foreach (ILogProvider provider in providers)
+        {
+            services.AddSingleton(provider);
+        }
+
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+        return serviceProvider.GetRequiredService<ILoggerService>();
+    }
+}

--- a/tests/Hm.Logging.Tests/Hm.Logging.Tests.csproj
+++ b/tests/Hm.Logging.Tests/Hm.Logging.Tests.csproj
@@ -14,6 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/Hm.Logging.Tests/Mocks/FakeLogProvider.cs
+++ b/tests/Hm.Logging.Tests/Mocks/FakeLogProvider.cs
@@ -1,0 +1,23 @@
+﻿using Hm.Logging.Abstractions;
+using Hm.Logging.Models;
+
+namespace Hm.Logging.Tests.Mocks;
+
+internal sealed class FakeLogProvider : ILogProvider
+{
+    public List<LogEntry> Entries { get; } = [];
+
+    public bool ThrowException { get; set; }
+
+    public Task WriteAsync(LogEntry entry, CancellationToken cancellationToken = default)
+    {
+        if (ThrowException)
+        {
+            throw new InvalidOperationException("Provider failure.");
+        }
+
+        Entries.Add(entry);
+
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Objective

Add comprehensive unit tests for LoggerService orchestration behavior.

## Coverage

This PR validates:

- LogAsync execution flow
- Validation pipeline integration
- Minimum log level filtering
- Message normalization
- Maximum message length enforcement
- Provider dispatch orchestration
- Multiple provider execution behavior
- Exception propagation
- Trace context propagation
- Scope context propagation
- Metadata merge semantics
- Immutable log processing behavior
- CancellationToken propagation
- No-provider execution behavior

## Technical Notes

- Tests now resolve ILoggerService through the real DI pipeline using AddHmLogging.
- FakeLogProvider was introduced for orchestration validation scenarios.
- Moq is used only for CancellationToken propagation verification.
- Tests intentionally focus on observable behavior instead of internal implementation details.

## Related Issue

Resolves #46