### PR TITLE
[LIB] Define semantic versioning strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The library focuses on:
 - Multi-provider orchestration
 - Provider isolation
 - Metadata normalization
-- Enterprise-grade developer experience (DX)
+- Developer Experience (DX) focused
 
 Hm.Logging intentionally separates:
 - lightweight logging orchestration responsibilities
@@ -75,7 +75,7 @@ Hm.Logging avoids:
 - Provider failure diagnostics callbacks
 - CancellationToken propagation
 - Validation pipeline
-- XML documentation
+- XML documentation comments
 - Roslyn analyzer support
 - SonarCloud validated
 - High unit test coverage
@@ -92,7 +92,7 @@ dotnet add package Hm.Logging
 
 ---
 
-## Supported Platforms
+## Target Framework
 
 - .NET 10
 
@@ -609,6 +609,14 @@ await logger.LogAsync(
     LogEntry.Info("Cancellation example"),
     cancellationToken: cancellationToken);
 ```
+
+---
+
+## Versioning
+
+Hm.Logging follows Semantic Versioning (SemVer).
+
+For detailed release strategy and compatibility guidelines, see [VERSIONING.md](./VERSIONING.md).
 
 ---
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,73 @@
+# Versioning Strategy
+
+Hm.Logging follows Semantic Versioning (SemVer).
+
+Version format:
+
+`MAJOR.MINOR.PATCH`
+
+Example:
+
+1.2.3
+
+## Versioning Rules
+
+### MAJOR
+
+Incremented when introducing breaking changes to the public API.
+
+Examples:
+- Removing public members
+- Changing method signatures
+- Behavioral breaking changes
+- Removing providers or contracts
+
+### MINOR
+
+Incremented when introducing new backward-compatible features.
+
+Examples:
+- New providers
+- Additional logging capabilities
+- New configuration options
+- New extension methods
+
+### PATCH
+
+Incremented for backward-compatible fixes and internal improvements.
+
+Examples:
+- Bug fixes
+- Performance improvements
+- Internal refactors
+- Documentation corrections
+
+---
+
+## Pre-release Versions
+
+Before reaching stable production maturity, pre-release versions may be published using suffixes such as:
+
+`0.1.0-preview.1`
+
+Pre-release versions may introduce API adjustments based on architectural improvements and community feedback.
+
+---
+
+## Compatibility Policy
+
+Minor and patch releases aim to preserve backward compatibility whenever possible.
+
+Breaking changes are reserved for major releases.
+
+---
+
+## Version Source
+
+The package version is currently managed directly through the project `.csproj` file.
+
+---
+
+## Initial Release Strategy
+
+The project currently targets early pre-release distribution until the public API and provider ecosystem stabilize.

--- a/src/Hm.Logging/Hm.Logging.csproj
+++ b/src/Hm.Logging/Hm.Logging.csproj
@@ -3,7 +3,9 @@
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 
-		<Version>0.1.0</Version>
+		<Version>0.1.0-preview.1</Version>
+		<AssemblyVersion>0.1.0.0</AssemblyVersion>
+		<FileVersion>0.1.0.0</FileVersion>
 
 		<PackageId>Hm.Logging</PackageId>
 		<Authors>Holmes Mojica</Authors>


### PR DESCRIPTION
## Summary

Defines the initial Semantic Versioning (SemVer) strategy for Hm.Logging.

## Changes

- Added VERSIONING.md
- Defined SemVer policy
- Added prerelease strategy
- Added compatibility guidelines
- Added initial package version
- Updated README with versioning documentation reference

## Initial Version

0.1.0-preview.1

## Related Issue

Resolves #20 